### PR TITLE
Update VampPerms Index

### DIFF
--- a/VampPerms/index.html
+++ b/VampPerms/index.html
@@ -58,12 +58,6 @@ Arguments written in [ ] are needed always, [{ }] is needed sometimes and { } is
 | Command                                 | Explanation    | Node           |
 | :-------------------------------------- | :------------- | :------------- |
 |                                         | Grants the user to use Griefprevention's claim features. | griefprevention.user |
-<!-- Deactiveated Commands
-
-| /afk                                    | Toggles the player's AFK state. | nucleus.afk.base |
-| /helpop [message]                       | Sends a [message] to all available staff. | nucleus.helpop.base |
-
--->
 | /firstspawn                             | Teleports to the new player spawn point. | nucleus.firstspawn.base |
 | /getpos                                 | Gets the location of the executing player. | nucleus.getpos.base |
 | /home [{name}],<br>/deletehome [{name}] | A home is a personal warp. The standard [{name}] is 'home'. /home [{name}] teleports to the home called [{name}].<br>/deletehome [{name}] deletes the home called [{name}]. | nucleus.home.base |
@@ -99,6 +93,12 @@ Arguments written in [ ] are needed always, [{ }] is needed sometimes and { } is
 | /vampirism eye [0-14]                   | Changes eye appearance to [0-14]. | vampirism.eye |
 | /vampirism fang [0-5]                   | Changes fang appearance to [0-5]. | vampirism.fang |
 |                                         | | weight.0 |
+<!-- Deactiveated Commands
+
+| /afk                                    | Toggles the player's AFK state. | nucleus.afk.base |
+| /helpop [message]                       | Sends a [message] to all available staff. | nucleus.helpop.base |
+
+-->
 
 ## Helper
 **Task:** Help people with the mod and the different plugins. Solve small problems. Manage chat. Report to Trial-Mod+ if a bigger issue arises.

--- a/VampPerms/index.html
+++ b/VampPerms/index.html
@@ -68,7 +68,7 @@ Arguments written in [ ] are needed always, [{ }] is needed sometimes and { } is
 | /info                                   | Displays server information. | nucleus.info.base |
 | /kit [name]                             | Redeems the kit called [name]. | nucleus.kit.base |
 | /kits                                   | Displays all available kits. | nucleus.kit.list.base |
-| /kit guide                         | Redeems the "vamp_guide" kit. | nucleus.kits.vamp_guide |
+| /kit guide                              | Redeems the "vamp_guide" kit. | nucleus.kits.vamp_guide |
 | /list                                   | Lists all online players, exempt vanished. | nucleus.list.base |
 | /mail                                   | Retrieves mail that has been sent to the executing user. | nucleus.mail.base |
 | /mail clear                             | Clears the executing player's inbox. | nucleus.mail.base |
@@ -96,6 +96,7 @@ Arguments written in [ ] are needed always, [{ }] is needed sometimes and { } is
 <!-- Deactiveated Commands
 
 | /afk                                    | Toggles the player's AFK state. | nucleus.afk.base |
+| /kit Claim                              | Redeems the "Claim" kit. | nucleus.kits.Claim |
 | /helpop [message]                       | Sends a [message] to all available staff. | nucleus.helpop.base |
 
 -->


### PR DESCRIPTION
Currently [VampPerms](https://1literzinalco.github.io/VampPerms/) formatting is broken, probably due to the hidden commands. This patch moves the hidden commands below the Default's group command list.